### PR TITLE
fix: flaky blackhole and dns tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,6 @@ defaults:
   run:
     shell: pwsh
 
-env:
-  GOCACHE: D:\gocache
-  GOMODCACHE: D:\gomodcache
-  GOTMPDIR: D:\gotmp
-
-
 jobs:
   audit:
     name: Audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ defaults:
   run:
     shell: pwsh
 
+env:
+  GOCACHE: D:\gocache
+  GOMODCACHE: D:\gomodcache
+  GOTMPDIR: D:\gotmp
+
+
 jobs:
   audit:
     name: Audit

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -6,6 +6,11 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
 	"github.com/rs/zerolog/log"
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	"github.com/steadybit/action-kit/go/action_kit_commons/network"
@@ -16,10 +21,6 @@ import (
 	"github.com/steadybit/extension-kit/extutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net"
-	"strconv"
-	"testing"
-	"time"
 )
 
 var (
@@ -29,8 +30,8 @@ var (
 				Name:    "extension",
 				Url:     "localhost",
 				Cidr:    "0.0.0.0/0",
-				PortMin: 8085,
-				PortMax: 8085,
+				PortMin: 8084,
+				PortMax: 8084,
 			},
 		}),
 	}
@@ -42,11 +43,12 @@ func TestWithLocalhost(t *testing.T) {
 	environment := newLocalEnvironment()
 	extFactory := LocalExtensionFactory{
 		Name: "extension-host-windows",
-		Port: 8085,
+		Port: 8084,
 		ExtraEnv: func() map[string]string {
 			return map[string]string{
 				"STEADYBIT_EXTENSION_DISCOVERY_ATTRIBUTES_EXCLUDES_HOST": "host.nic",
 				"STEADYBIT_EXTENSION_LOGGING_LEVEL":                      "trace",
+				"STEADYBIT_LOG_LEVEL":                                    "trace",
 			}
 		},
 	}
@@ -59,31 +61,12 @@ func TestWithLocalhost(t *testing.T) {
 			Name: "target discovery",
 			Test: testDiscovery,
 		}, {
-			Name: "stop process",
-			Test: testStopProcess,
-		}, {
-			Name: "network delay",
-			Test: testNetworkDelay,
-		}, {
 			Name: "network blackhole",
 			Test: testNetworkBlackhole,
 		}, {
 			Name: "network block dns",
 			Test: testNetworkBlockDns,
-		}, {
-			Name: "network limit bandwidth",
-			Test: testNetworkLimitBandwidth,
-		}, {
-			Name: "network package loss",
-			Test: testNetworkPackageLoss,
-		}, {
-			Name: "network package corruption",
-			Test: testNetworkPackageCorruption,
-		}, {
-			Name: "two simultaneous network attacks should error",
-			Test: testTwoNetworkAttacks,
-		},
-	})
+		}})
 }
 
 func validateDiscovery(t *testing.T, _ Environment, e Extension) {
@@ -724,8 +707,8 @@ func generateRestrictedEndpoints(count int) []action_kit_api.RestrictedEndpoint 
 	for i := 0; i < count; i++ {
 		result = append(result, action_kit_api.RestrictedEndpoint{
 			Cidr:    fmt.Sprintf("%s/32", address.String()),
-			PortMin: 8085,
-			PortMax: 8086,
+			PortMin: 8084,
+			PortMax: 8085,
 		})
 		incrementIP(address, len(address)-1)
 	}

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -61,12 +61,31 @@ func TestWithLocalhost(t *testing.T) {
 			Name: "target discovery",
 			Test: testDiscovery,
 		}, {
+			Name: "stop process",
+			Test: testStopProcess,
+		}, {
+			Name: "network delay",
+			Test: testNetworkDelay,
+		}, {
 			Name: "network blackhole",
 			Test: testNetworkBlackhole,
 		}, {
 			Name: "network block dns",
 			Test: testNetworkBlockDns,
-		}})
+		}, {
+			Name: "network limit bandwidth",
+			Test: testNetworkLimitBandwidth,
+		}, {
+			Name: "network package loss",
+			Test: testNetworkPackageLoss,
+		}, {
+			Name: "network package corruption",
+			Test: testNetworkPackageCorruption,
+		}, {
+			Name: "two simultaneous network attacks should error",
+			Test: testTwoNetworkAttacks,
+		},
+	})
 }
 
 func validateDiscovery(t *testing.T, _ Environment, e Extension) {

--- a/e2e/startHttpServer.ps1
+++ b/e2e/startHttpServer.ps1
@@ -5,34 +5,37 @@ $l.Prefixes.Add("http://{{.Ip}}:{{nextPort .Port}}/");
 $l.Start();
 Write-Host "Listening on http://{{.Ip}}:{{.Port}}/";
 while ($l.IsListening) {
-  $con = $l.GetContext();
-  $req = $con.Request;
-  $res = $con.Response;
-  if ($req.Url.Query -match "url=([^&]+)") {
-    try {
-      $targetUrl = [System.Web.HttpUtility]::UrlDecode($matches[1]);
-      if (-not $targetUrl.StartsWith("http")) {
-        $targetUrl = "http://" + $targetUrl
-      };
+    $con = $l.GetContext();
+    $req = $con.Request;
+    $res = $con.Response;
 
-      # Use Invoke-WebRequest instead of WebClient
-      $userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";
-      $response = Invoke-WebRequest -Uri $targetUrl -UserAgent $userAgent -UseBasicParsing;
+    if ($req.Url.Query -match "url=([^&]+)") {
+        try {
+            $targetUrl = [System.Web.HttpUtility]::UrlDecode($matches[1]);
+            if (-not $targetUrl.StartsWith("http")) {
+                $targetUrl = "http://" + $targetUrl;
+            }
 
-      # Handle the content based on the content type
-      $contentBytes = [System.Text.Encoding]::UTF8.GetBytes($response.Content);
-      if ($response.Headers.ContainsKey("Content-Type")) {
-        $res.ContentType = $response.Headers["Content-Type"];
-      }
+            $userAgent = "Mozilla/5.0 ... Chrome";
+            $response = Invoke-WebRequest -Uri $targetUrl -UserAgent $userAgent -UseBasicParsing;
 
-      $res.OutputStream.Write($contentBytes, 0, $contentBytes.Length);
-    } catch {
-      $err = [System.Text.Encoding]::UTF8.GetBytes("Proxy error: $_");
-      $res.StatusCode = 500;
-      $res.OutputStream.Write($err, 0, $err.Length);
+            $contentBytes = [System.Text.Encoding]::UTF8.GetBytes($response.Content);
+
+            if ($response.Headers["Content-Type"]) {
+                $res.ContentType = $response.Headers["Content-Type"];
+            }
+
+            $res.ContentLength64 = $contentBytes.Length
+            $res.OutputStream.Write($contentBytes, 0, $contentBytes.Length);
+        } catch {
+            $err = [System.Text.Encoding]::UTF8.GetBytes("Proxy error: $_");
+            $res.StatusCode = 500;
+            $res.OutputStream.Write($err, 0, $err.Length);
+        }
+    } else {
+        $c = [System.Text.Encoding]::UTF8.GetBytes("<html><body>Hello, Windows HTTP Server</body></html>");
+        $res.OutputStream.Write($c, 0, $c.Length);
     }
-  } else {
-    $c = [System.Text.Encoding]::UTF8.GetBytes("<html><body>Hello, Windows HTTP Server</body></html>");
-    $res.OutputStream.Write($c, 0, $c.Length);
-  };
+    $res.OutputStream.Flush()
+    $res.Close()
 }


### PR DESCRIPTION
- set integration test port to 8084 instead of 8085 so we don't get overlaps if the system already has extension host installed.
- few improvements on startHttpServer script.