### PR TITLE
fix: installer improvements

### DIFF
--- a/windowspkg/WindowsHostExtensionInstaller/Components.wxs
+++ b/windowspkg/WindowsHostExtensionInstaller/Components.wxs
@@ -6,12 +6,12 @@
         <File Source="./Artifacts/wdna_shutdown.exe" />
         <File Source="./Artifacts/WinDivert.dll" />
         <File Source="./Artifacts/WinDivert64.sys" />
-				<Environment Id="WdnaPath" Name="PATH" Value="[WDNAFOLDER]" Part="last" Permanent="yes" Action="set" System="yes"/>
+				<Environment Id="WdnaPath" Name="PATH" Value="[WDNAFOLDER]" Part="last" Permanent="no" Action="set" System="yes"/>
       </Component>
     </ComponentGroup>
     <ComponentGroup Id="CORE" Directory="COREFOLDER">
       <Component Guid="12621f61-666b-40f4-ac24-d02e4d5436ed">
-				<Environment Id="ExtensionPort" Name="STEADYBIT_EXTENSION_PORT" Value="8000" Part="last" Permanent="yes" Action="set" System="yes"/>
+				<Environment Id="ExtensionPort" Name="STEADYBIT_EXTENSION_PORT" Value="8085" Permanent="yes" Action="create" System="yes"/>
         <File Source="./Artifacts/extension-host-windows.exe" KeyPath="yes"/>
 				<ServiceInstall Id="ServiceInstall" Type="ownProcess" Name="SteadybitWindowsHostExtension" DisplayName="!(bind.Property.ProductName)" Start="auto" Vital="yes" ErrorControl="normal"/>
 				<ServiceControl Id="StartService" Name="SteadybitWindowsHostExtension" Start="install" Stop="both" Remove="uninstall" Wait="yes"/>

--- a/windowspkg/WindowsHostExtensionInstaller/Package.wxs
+++ b/windowspkg/WindowsHostExtensionInstaller/Package.wxs
@@ -20,6 +20,6 @@
 		<Property Id="ARPPRODUCTICON" Value="icon"/>
 
 		<util:QueryNativeMachine/>
-		<Launch Condition="WIX_NATIVE_MACHINE = 34404" Message="x64 is the only supported architecture. Current architecture is [WIX_NATIVE_MACHINE]."/>
+		<Launch Condition="Installed OR WIX_NATIVE_MACHINE = 34404" Message="x64 is the only supported architecture. Current architecture is [WIX_NATIVE_MACHINE]."/>
   </Package>
 </Wix>


### PR DESCRIPTION
- STEADYBIT_EXTENSION_PORT is created if it does not exist, it is permanent and won't be removed on the uninstall (someone might want to remove the current version and upgrade and non-permanent would remove the previous configuration)
- STEADYBIT_EXTENSION_PORT default changed to 8085
- WDNA path is not permanent due to the possibility of path changing depending on the version of the installer.
- when propted to uninstall it would show that architecture is incorrect. Query native machine only executes on the initial installation and not on uninstall. Condition is expanded to cover that case.