### PR TITLE
fix: installer licenses report is mandatory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,8 @@ jobs:
         run: |
           make installer
         shell: powershell
+        env:
+          SKIP_LICENSES_REPORT: false
 
       - name: Upload Artifacts
         id: artifact-upload

--- a/scripts/package-installer.ps1
+++ b/scripts/package-installer.ps1
@@ -1,6 +1,6 @@
 if (-not ($Env:SKIP_LICENSES_REPORT -eq "false")){
     Write-Output "License report must be set to 'false' in order to package the installer."
-    return
+    return 1
 }
 
 $scriptPath = $PSScriptRoot


### PR DESCRIPTION
- installer powershell script returns 1 if the SKIP_LICENSES_REPORT is anything other than false
- add env variable to the installer pipeline