### PR TITLE
fix: Respect IP/CIDR restrictions in limit bandwidth attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ STEADYBIT_AGENT_EXTENSIONS_REGISTRATIONS_0_URL=http://<extension-windows-host-ip
 
 We try to limit the permissions required by the extension to the absolute minimum.
 
-In order to execute network attacks the extension needs to be executed as an `Administrator`. Furthermore, the limit outgoing bandwidth attack creates and removed network QoS policies in the `SYSTEM` context.
+In order to execute network attacks the extension needs to be executed as `Administrator`. Furthermore, the limit outgoing bandwidth attack creates and removes network QoS policies in the `SYSTEM` context.
 
 ## Troubleshooting
 

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -255,6 +255,11 @@ func testNetworkBlackhole(t *testing.T, l Environment, e Extension) {
 	require.NoError(t, err)
 	defer func() { _ = netperf.Delete() }()
 
+	var steadybitAddresses []string
+	for _, ip := range steadybitIPs {
+		steadybitAddresses = append(steadybitAddresses, ip.String())
+	}
+
 	tests := []struct {
 		name       string
 		ip         []string
@@ -279,7 +284,7 @@ func testNetworkBlackhole(t *testing.T, l Environment, e Extension) {
 		},
 		{
 			name:       "should blackhole traffic to ip",
-			ip:         []string{steadybitIPs[0].String()},
+			ip:         steadybitAddresses,
 			wantedDrop: true,
 		},
 		{

--- a/exthostwindows/action_network_bandwidth.go
+++ b/exthostwindows/action_network_bandwidth.go
@@ -78,9 +78,9 @@ func getNetworkLimitBandwidthDescription() action_kit_api.ActionDescription {
 			},
 			{
 				Name:         "port",
-				Label:        "Ports",
-				Description:  extutil.Ptr("Restrict to/from which ports the traffic is affected."),
-				Type:         action_kit_api.ActionParameterTypeStringArray,
+				Label:        "Port",
+				Description:  extutil.Ptr("Restrict to/from which port the traffic is affected."),
+				Type:         action_kit_api.ActionParameterTypeString,
 				DefaultValue: extutil.Ptr(""),
 				Advanced:     extutil.Ptr(true),
 				Order:        extutil.Ptr(103),

--- a/exthostwindows/network/bandwidth_test.go
+++ b/exthostwindows/network/bandwidth_test.go
@@ -1,20 +1,23 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
+
 package network
 
 import (
-	"github.com/steadybit/extension-host-windows/exthostwindows/utils"
 	"github.com/stretchr/testify/require"
 	"net"
 	"testing"
 )
 
 func Test_LimitBandwidth_create_one_policy_per_ip(t *testing.T) {
-	expectedPolicyName1 := "steadybit_qos_100mb_0"
-	_, ipNet1, err := net.ParseCIDR("1.1.1.1/32")
+	err := removeSteadybitQosPolicies(t.Context())
 	require.NoError(t, err)
 
-	expectedPolicyName2 := "steadybit_qos_100mb_1"
-	_, ipNet2, err := net.ParseCIDR("1.1.1.2/32")
-	require.NoError(t, err)
+	expectedPolicyName1 := "STEADYBIT_QOS_100MB_0"
+	_, ipNet1, _ := net.ParseCIDR("1.1.1.1/32")
+
+	expectedPolicyName2 := "STEADYBIT_QOS_100MB_1"
+	_, ipNet2, _ := net.ParseCIDR("1.1.1.2/32")
 
 	limitBandwidthOpts := LimitBandwidthOpts{
 		Bandwidth: "100MB",
@@ -30,19 +33,14 @@ func Test_LimitBandwidth_create_one_policy_per_ip(t *testing.T) {
 	defer func() {
 		err := Revert(t.Context(), &limitBandwidthOpts)
 		require.NoError(t, err)
-		out, err := listQoSPolicies(t)
+		policies, err := listSteadybitQosPolicyNames(t.Context())
 		require.NoError(t, err)
-		require.NotContains(t, out, expectedPolicyName1)
-		require.NotContains(t, out, expectedPolicyName2)
+		require.NotContains(t, policies, expectedPolicyName1)
+		require.NotContains(t, policies, expectedPolicyName2)
 	}()
 
-	out, err := listQoSPolicies(t)
+	policies, err := listSteadybitQosPolicyNames(t.Context())
 	require.NoError(t, err)
-	require.Contains(t, out, expectedPolicyName1)
-	require.Contains(t, out, expectedPolicyName2)
-}
-
-func listQoSPolicies(t *testing.T) (string, error) {
-	listQosPoliciesCommand := []string{"Get-NetQosPolicy -PolicyStore ActiveStore"}
-	return utils.Execute(t.Context(), listQosPoliciesCommand, utils.PSRun)
+	require.Contains(t, policies, expectedPolicyName1)
+	require.Contains(t, policies, expectedPolicyName2)
 }

--- a/exthostwindows/network/network.go
+++ b/exthostwindows/network/network.go
@@ -124,7 +124,7 @@ func ExecuteWinDivertCommands(ctx context.Context, cmds []string, mode Mode) (st
 		return "", nil
 	}
 
-	out, err := utils.Execute(ctx, utils.SanitizePowershellArgs(cmds...), utils.PSStart)
+	out, err := utils.ExecutePowershellCommand(ctx, utils.SanitizePowershellArgs(cmds...), utils.PSStart)
 	if err == nil {
 		timeout := 10 * time.Second
 		if mode == ModeAdd {
@@ -144,5 +144,5 @@ func executeQoSCommands(ctx context.Context, cmds []string) (string, error) {
 		return "", nil
 	}
 
-	return utils.Execute(ctx, cmds, utils.PSRun)
+	return utils.ExecutePowershellCommand(ctx, cmds, utils.PSRun)
 }

--- a/exthostwindows/network/network_test.go
+++ b/exthostwindows/network/network_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
+
+package network
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestCleanupQosPolicies(t *testing.T) {
+	// Cleanup works if no leftover policies exist
+	CleanupQosPolicies()
+
+	// Cleanup does not run if experiment is active
+	createQosPolicy(t, qosPolicyPrefix+"test_policy_cleanup")
+	opts := &MockNetworkOpt{}
+	err := generateAndRunCommands(t.Context(), opts, ModeAdd)
+	require.NoError(t, err)
+
+	CleanupQosPolicies()
+
+	policies, err := listSteadybitQosPolicyNames(t.Context())
+	require.NoError(t, err)
+	assert.NotEmpty(t, policies)
+
+	// Cleanup removes leftover policies after the experiment has finished
+	err = generateAndRunCommands(t.Context(), opts, ModeDelete)
+	require.NoError(t, err)
+
+	CleanupQosPolicies()
+
+	policies, err = listSteadybitQosPolicyNames(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, policies)
+}
+
+type MockNetworkOpt struct{}
+
+func (o *MockNetworkOpt) WinDivertCommands(_ Mode) ([]string, error) {
+	return nil, nil
+}
+
+func (o *MockNetworkOpt) QoSCommands(_ Mode) ([]string, error) {
+	return nil, nil
+}
+
+func (o *MockNetworkOpt) String() string {
+	return "MockNetworkOpt"
+}

--- a/exthostwindows/network/qospolicies.go
+++ b/exthostwindows/network/qospolicies.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"github.com/rs/zerolog/log"
+	"github.com/steadybit/extension-host-windows/exthostwindows/utils"
+	"strings"
+)
+
+const qosPolicyPrefix = "STEADYBIT_QOS_"
+
+func logCurrentQoSRules(ctx context.Context, when string) {
+	if !log.Trace().Enabled() {
+		return
+	}
+	policies, err := listSteadybitQosPolicies(ctx)
+	if err != nil {
+		log.Trace().Err(err).Msg("failed to get current QoS rules")
+	} else {
+		log.Trace().Str("when", when).Strs("policies", policies).Msg("current QoS policies")
+	}
+}
+
+func listSteadybitQosPolicies(ctx context.Context) ([]string, error) {
+	listCommand := "Get-NetQosPolicy | Where-Object { $_.Name -like \"" + qosPolicyPrefix + "*\" }"
+	result, err := utils.ExecutePowershellCommand(ctx, []string{listCommand}, utils.PSRun)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list QoS policies: %w", err)
+	}
+	var policies []string
+	blocks := strings.Split(result, "\r\n\r\n")
+	for _, block := range blocks {
+		if block != "" {
+			policies = append(policies, block)
+		}
+	}
+	return policies, nil
+}
+
+func listSteadybitQosPolicyNames(ctx context.Context) ([]string, error) {
+	listCommand := "Get-NetQosPolicy | Where-Object { $_.Name -like \"" + qosPolicyPrefix + "*\" } | Select-Object -ExpandProperty Name"
+	result, err := utils.ExecutePowershellCommand(ctx, []string{listCommand}, utils.PSRun)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list QoS policies: %w", err)
+	}
+	var policies []string
+	blocks := strings.Split(result, "\r\n")
+	for _, block := range blocks {
+		if block != "" {
+			policies = append(policies, block)
+		}
+	}
+	return policies, nil
+}
+
+func removeSteadybitQosPolicies(ctx context.Context) error {
+	policies, err := listSteadybitQosPolicyNames(ctx)
+	if err != nil {
+		return err
+	}
+	if len(policies) == 0 {
+		return nil
+	}
+
+	log.Error().Strs("policies", policies).Msg("Found leftover QoS policies, removing them")
+	return removeQoSPolicies(ctx, policies)
+}
+
+func removeQoSPolicies(ctx context.Context, policies []string) error {
+	var errors []string
+	for _, policy := range policies {
+		removeCommand := fmt.Sprintf("Remove-NetQosPolicy -Name %s -Confirm:$false", policy)
+		if _, err := utils.ExecutePowershellCommand(ctx, []string{removeCommand}, utils.PSRun); err != nil {
+			errors = append(errors, err.Error())
+		}
+	}
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to remove QoS policies: %s", strings.Join(errors, "; "))
+	}
+	return nil
+}

--- a/exthostwindows/network/qospolicies_test.go
+++ b/exthostwindows/network/qospolicies_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
+
+package network
+
+import (
+	"fmt"
+	"github.com/steadybit/extension-host-windows/exthostwindows/utils"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/rand"
+	"strconv"
+	"testing"
+)
+
+func TestListSteadybitQosPolicyNames(t *testing.T) {
+	err := removeSteadybitQosPolicies(t.Context())
+	require.NoError(t, err)
+
+	testQosPolicyName := qosPolicyPrefix + "test_" + strconv.Itoa(rand.Intn(100000))
+	createQosPolicy(t, testQosPolicyName)
+	defer func() {
+		err := removeQoSPolicies(t.Context(), []string{testQosPolicyName})
+		require.NoError(t, err)
+	}()
+
+	qosPolicyNames, err := listSteadybitQosPolicyNames(t.Context())
+	require.NoError(t, err)
+	require.Contains(t, qosPolicyNames, testQosPolicyName)
+}
+
+func TestListSteadybitQosPolicies(t *testing.T) {
+	err := removeSteadybitQosPolicies(t.Context())
+	require.NoError(t, err)
+
+	testQosPolicyName := qosPolicyPrefix + "test_" + strconv.Itoa(rand.Intn(100000))
+	createQosPolicy(t, testQosPolicyName)
+	defer func() {
+		err := removeQoSPolicies(t.Context(), []string{testQosPolicyName})
+		require.NoError(t, err)
+	}()
+
+	qosPolicyNames, err := listSteadybitQosPolicies(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, qosPolicyNames)
+}
+
+func createQosPolicy(t *testing.T, name string) {
+	command := fmt.Sprintf("New-NetQosPolicy -Name %s -ThrottleRateActionBitsPerSecond 100MB -Confirm:$false", name)
+	_, err := utils.ExecutePowershellCommand(t.Context(), []string{command}, utils.PSRun)
+	require.NoError(t, err)
+}

--- a/exthostwindows/utils/hostnames.go
+++ b/exthostwindows/utils/hostnames.go
@@ -90,7 +90,7 @@ func (i *HostnameInput) Resolve(ctx context.Context) (*HostnameOutput, error) {
 				SanitizePowershellArg(i.Hostname),
 				SanitizePowershellArg(record)),
 		}
-		out, err := Execute(ctx, cmd, PSRun)
+		out, err := ExecutePowershellCommand(ctx, cmd, PSRun)
 		if err != nil {
 			return nil, fmt.Errorf("could not resolve hostnames: %w", err)
 		}

--- a/exthostwindows/utils/shell.go
+++ b/exthostwindows/utils/shell.go
@@ -24,7 +24,7 @@ const (
 // ExecutePowershellCommand runs the given commands in a powershell session.
 // Callers must make sure that passed in commands are properly sanitizes.
 func ExecutePowershellCommand(ctx context.Context, cmds []string, shell Shell) (string, error) {
-	log.Info().Strs("cmds", cmds).Msg("running commands")
+	log.Debug().Strs("cmds", cmds).Msg("running commands")
 
 	commands := strings.Join(cmds, ";")
 

--- a/exthostwindows/utils/shell.go
+++ b/exthostwindows/utils/shell.go
@@ -53,7 +53,7 @@ func BuildSystemCommandFor(cmd string) []string {
 	principal := "$P=New-ScheduledTaskPrincipal -UserId \"SYSTEM\" -RunLevel Highest"
 	registerScheduledTask := "Register-ScheduledTask SteadybitTempQoSPolicyTask -Action $A -Principal $P"
 	startTask := "Start-ScheduledTask SteadybitTempQoSPolicyTask"
-	awaitExecution := "Start-Sleep -Milliseconds 100;for($i=0;$i -lt 20;$i++){if((Get-ScheduledTask -TaskName SteadybitTempQoSPolicyTask).State -ne 'Running'){break};Start-Sleep -Milliseconds 500};"
+	awaitExecution := "for($i=0;$i -lt 20;$i++){if((Get-ScheduledTask -TaskName SteadybitTempQoSPolicyTask).State -ne 'Running'){break};Start-Sleep -Milliseconds 100};"
 	unregisterScheduledTask := "Unregister-ScheduledTask SteadybitTempQoSPolicyTask -Confirm:$false"
 	return []string{scheduledTaskAction, principal, registerScheduledTask, startTask, awaitExecution, unregisterScheduledTask}
 }

--- a/exthostwindows/utils/shell.go
+++ b/exthostwindows/utils/shell.go
@@ -21,9 +21,9 @@ const (
 	PSRun   Shell = "PSRun"
 )
 
-// Execute runs the given commands in a powershell session.
+// ExecutePowershellCommand runs the given commands in a powershell session.
 // Callers must make sure that passed in commands are properly sanitizes.
-func Execute(ctx context.Context, cmds []string, shell Shell) (string, error) {
+func ExecutePowershellCommand(ctx context.Context, cmds []string, shell Shell) (string, error) {
 	log.Info().Strs("cmds", cmds).Msg("running commands")
 
 	commands := strings.Join(cmds, ";")

--- a/main.go
+++ b/main.go
@@ -24,8 +24,12 @@ import (
 func main() {
 	extlogging.InitZeroLog()
 
+	// Register a QoS policy cleanup routine as additional safeguard.
+	stopQosCleanup := exthostwindows.RegisterQosPolicyCleanup()
+
 	// Register Windows Service early during startup to log messages as Windows application events
 	exthostwindows.ActivateWindowsServiceHandler(func() {
+		stopQosCleanup()
 		exthttp.StopListen()
 	})
 


### PR DESCRIPTION
The -ThrottleRateActionBitsPerSecond parameter of QoS policies can not be used simultaneously with -PolicyStore ActiveStore. Though not using ActiveStore persists policies even after a reboot. To address potential leftover policies—such as those caused by a terminated extension during an ongoing experiment—a periodic cleanup routine has been introduced.