### PR TITLE
feat: updates to match the agent release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
         with:
           name: ${{ github.head_ref || github.ref_name }}
           path: |
+            dist/*.zip
             dist/*.msi
           retention-days: 7
 
@@ -131,6 +132,40 @@ jobs:
           prerelease: ${{ !contains(github.ref, '-') }}
           fail_on_unmatched_files: true
           files: "dist/*.zip"
+
+  upload-to-s3:
+    needs: build
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    steps:
+      - name: Configure AWS Credentials 
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: 'eu-central-1'
+          role-to-assume: 'arn:aws:iam::292929100161:role/allow-auto-deploy-from-other-accounts'
+          role-duration-seconds: 900
+          role-session-name: S3DeployWindowsArtifacts
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "${{ github.head_ref || github.ref_name }}"
+          path: artifact/
+
+      - name: Zip artifact
+        run: |
+          ARTIFACT_NAME="${{ github.head_ref || github.ref_name }}"
+          zip $ARTIFACT_NAME.zip artifact/*.msi
+          zip latest.zip artifact/*.msi
+        
+      - name: Upload to S3
+        run: |
+          ARTIFACT_NAME="${{ github.head_ref || github.ref_name }}"
+          aws s3 cp latest.zip s3://steadybit-shared-eu-central-1-windows-artifacts-public/steadybit-agent/ 
+          aws s3 cp $ARTIFACT_NAME.zip s3://steadybit-shared-eu-central-1-windows-artifacts-public/steadybit-agent/ 
 
   refresh-demo:
     name: Refresh Dev Demo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,12 +147,14 @@ jobs:
           path: artifact/
 
       - name: Zip artifact
+        shell: bash
         run: |
           ARTIFACT_NAME="${{ github.head_ref || github.ref_name }}"
           zip $ARTIFACT_NAME.zip artifact/*.msi
           zip latest.zip artifact/*.msi
         
       - name: Upload to S3
+        shell: bash
         run: |
           ARTIFACT_NAME="${{ github.head_ref || github.ref_name }}"
           aws s3 cp latest.zip s3://steadybit-shared-eu-central-1-windows-artifacts-public/steadybit-extension-host-windows/ 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,8 @@ jobs:
         id: artifact-upload
         uses: actions/upload-artifact@v4
         with:
+          name: ${{ github.ref_name }}
           path: |
-            dist/*.zip
             dist/*.msi
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,8 @@ jobs:
       - name: Upload to S3
         run: |
           ARTIFACT_NAME="${{ github.head_ref || github.ref_name }}"
-          aws s3 cp latest.zip s3://steadybit-shared-eu-central-1-windows-artifacts-public/steadybit-agent/ 
-          aws s3 cp $ARTIFACT_NAME.zip s3://steadybit-shared-eu-central-1-windows-artifacts-public/steadybit-agent/ 
+          aws s3 cp latest.zip s3://steadybit-shared-eu-central-1-windows-artifacts-public/steadybit-extension-host-windows/ 
+          aws s3 cp $ARTIFACT_NAME.zip s3://steadybit-shared-eu-central-1-windows-artifacts-public/steadybit-extension-host-windows/ 
 
   refresh-demo:
     name: Refresh Dev Demo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,9 @@ jobs:
         shell: bash
         run: |
           ARTIFACT_NAME="${{ github.head_ref || github.ref_name }}"
-          aws s3 cp latest.zip s3://steadybit-shared-eu-central-1-windows-artifacts-public/steadybit-extension-host-windows/ 
-          aws s3 cp $ARTIFACT_NAME.zip s3://steadybit-shared-eu-central-1-windows-artifacts-public/steadybit-extension-host-windows/ 
+          aws s3 cp latest.zip s3://windows-registry-steadybit/steadybit-agent/ 
+          aws s3 cp $ARTIFACT_NAME.zip s3://windows-registry-steadybit/steadybit-agent/ 
+
 
   refresh-demo:
     name: Refresh Dev Demo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         id: artifact-upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.ref_name }}
+          name: ${{ github.head_ref || github.ref_name }}
           path: |
             dist/*.msi
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,6 @@ jobs:
           make audit
         shell: powershell
 
-      - name: "[release] Snyk test"
-        if: ${{ startsWith(github.ref, 'refs/tags/') && env.snyk_available == 'true' }}
-        uses: snyk/actions/golang@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --org=${{ vars.SNYK_ORG_ID }} --severity-threshold=high --project-name=${{ github.repository }} --target-reference=${{ github.ref_name }}
-          command: test
-
       - name: SonarCloud Scan
         if: ${{ env.sonar_available == 'true' }}
         uses: sonarsource/sonarqube-scan-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,8 @@ jobs:
         shell: bash
         run: |
           ARTIFACT_NAME="${{ github.head_ref || github.ref_name }}"
-          aws s3 cp latest.zip s3://windows-registry-steadybit/steadybit-extension-host-windows/ 
-          aws s3 cp $ARTIFACT_NAME.zip s3://windows-registry-steadybit/steadybit-extension-host-windows/ 
+          aws s3 cp latest.zip s3://windows-registry.steadybit.com/steadybit-extension-host-windows/ 
+          aws s3 cp $ARTIFACT_NAME.zip s3://windows-registry.steadybit.com/steadybit-extension-host-windows/ 
 
 
   refresh-demo:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,8 @@ jobs:
         shell: bash
         run: |
           ARTIFACT_NAME="${{ github.head_ref || github.ref_name }}"
-          aws s3 cp latest.zip s3://windows-registry-steadybit/steadybit-agent/ 
-          aws s3 cp $ARTIFACT_NAME.zip s3://windows-registry-steadybit/steadybit-agent/ 
+          aws s3 cp latest.zip s3://windows-registry-steadybit/steadybit-extension-host-windows/ 
+          aws s3 cp $ARTIFACT_NAME.zip s3://windows-registry-steadybit/steadybit-extension-host-windows/ 
 
 
   refresh-demo:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The extension supports all environment variables provided by [steadybit/extensio
 
 **Note**: Only x64 systems are supported.
 
-Once available, download the latest Windows installer from the project`s [GitHub release page](https://github.com/steadybit/WinDivert/releases).
+Once available, download the latest Windows installer from the project`s [GitHub release page](https://github.com/steadybit/WinDivert/releases) or [S3 Directory Listing](https://steadybit-shared-eu-central-1-windows-artifacts-public.s3.amazonaws.com/index.html).
 
 As the extension requires extended privileges to execute host attacks, like injecting network traffic errors, the installer and the extension need to be executed as an **Administrator user**.
 During installation, a Windows Service named `SteadybitWindowsExtensionHost` is created and configured. It runs on startup on port `8085`.

--- a/exthostwindows/common.go
+++ b/exthostwindows/common.go
@@ -5,12 +5,13 @@ package exthostwindows
 
 import (
 	"fmt"
-	"github.com/steadybit/action-kit/go/action_kit_api/v2"
-	"github.com/steadybit/extension-host-windows/exthostwindows/network"
-	"github.com/steadybit/extension-kit"
-	"github.com/steadybit/extension-kit/extutil"
 	"os"
 	"time"
+
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-host-windows/exthostwindows/network"
+	extension_kit "github.com/steadybit/extension-kit"
+	"github.com/steadybit/extension-kit/extutil"
 )
 
 const (
@@ -84,10 +85,11 @@ func getRestrictedEndpoints(request action_kit_api.PrepareActionRequestBody) []a
 }
 
 func RegisterQosPolicyCleanup() func() {
-	var stop chan struct{}
+	stop := make(chan struct{})
 
 	go func() {
 		ticker := time.NewTicker(60 * time.Second)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:

--- a/windowspkg/WindowsHostExtensionInstaller/Package.wxs
+++ b/windowspkg/WindowsHostExtensionInstaller/Package.wxs
@@ -2,7 +2,7 @@
 		 xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui"
 		 xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util"
 		 >
-  <Package Name="Windows Host Extension" Manufacturer="Steadybit GmbH" Version="1.0.0.0" UpgradeCode="3e616adc-d783-486a-83ff-333d45c856f6">
+  <Package Name="Steadybit Windows Host Extension" Manufacturer="Steadybit GmbH" Version="1.0.0.0" UpgradeCode="3e616adc-d783-486a-83ff-333d45c856f6">
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." AllowSameVersionUpgrades="no"/>
 		<Media Id="1" EmbedCab="yes" Cabinet="cab1"/>
 

--- a/windowspkg/WindowsHostExtensionInstaller/WindowsHostExtensionInstaller.wixproj
+++ b/windowspkg/WindowsHostExtensionInstaller/WindowsHostExtensionInstaller.wixproj
@@ -1,6 +1,6 @@
 <Project Sdk="WixToolset.Sdk/5.0.2">
   <PropertyGroup>
-    <OutputName>SteadybitWindowsHostExtension</OutputName>
+    <OutputName>SteadybitWindowsHostExtensionInstaller</OutputName>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="icon.ico" />


### PR DESCRIPTION
No need for .zip release. The .msi installer is going to be zipped and the artifact is going to be named by the github_ref.

Goal is to upload the artifact to the s3 bucket with the version/tag name and therefore the download links are going to be simple and deterministic.