### PR TITLE
feat: testsigning transparency

### DIFF
--- a/exthostwindows/action_network.go
+++ b/exthostwindows/action_network.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/steadybit/extension-host-windows/exthostwindows/network"
-	"github.com/steadybit/extension-host-windows/exthostwindows/utils"
 	"net"
 	"strings"
+
+	"github.com/rs/zerolog/log"
+	"github.com/steadybit/extension-host-windows/exthostwindows/network"
+	"github.com/steadybit/extension-host-windows/exthostwindows/utils"
 
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	akn "github.com/steadybit/action-kit/go/action_kit_commons/network"
@@ -122,6 +124,17 @@ func (a *networkAction) Prepare(ctx context.Context, state *NetworkActionState, 
 }
 
 func (a *networkAction) Start(ctx context.Context, state *NetworkActionState) (*action_kit_api.StartResult, error) {
+	isTestSigningEnabled, err := utils.IsTestSigningEnabled()
+	if err != nil {
+		return nil, extensionKit.ToError("Error retrieving testsigning flag from the bcdedit.", err)
+	}
+
+	if !isTestSigningEnabled {
+		return nil, fmt.Errorf("testsigning is not enabled on the machine, please follow the guide to enable it: https://github.com/steadybit/extension-host-windows?tab=readme-ov-file#pre-release-versions")
+	}
+
+	log.Debug().Msgf("testsigning is enabled on the machine")
+
 	opts, err := a.optsDecoder(state.NetworkOpts)
 	if err != nil {
 		return nil, extensionKit.ToError("Failed to deserialize network settings.", err)

--- a/exthostwindows/network/network.go
+++ b/exthostwindows/network/network.go
@@ -119,7 +119,7 @@ func popActiveFw(id string, opts WinOpts) {
 func executeWinDivertCommands(ctx context.Context, cmds []string, mode Mode) (string, error) {
 	out, err := utils.ExecutePowershellCommand(ctx, utils.SanitizePowershellArgs(cmds...), utils.PSStart)
 	if err == nil {
-		timeout := 10 * time.Second
+		timeout := 15 * time.Second
 		if mode == ModeAdd {
 			err = awaitWinDivertServiceStatus(svc.Running, timeout)
 			log.Debug().Msgf("WinDivert service is running")

--- a/exthostwindows/network/windivert.go
+++ b/exthostwindows/network/windivert.go
@@ -369,9 +369,12 @@ func awaitWinDivertServiceStatus(state svc.State, timeout time.Duration) error {
 	for time.Now().Before(end) {
 		s, err := m.OpenService("windivert")
 		if err != nil {
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
+			log.Debug().Msgf("failed opening the windivert service with error (retrying in 500ms): %v", err)
 			continue
 		}
+
+		log.Info().Msgf("successfully opened the windivert service.")
 		// deferred function is only created once
 		//goland:noinspection GoDeferInLoop
 		defer func(s *mgr.Service) {


### PR DESCRIPTION
- error emmited in the start call if the testsigning is not enabled
- retry interval increased from 100ms to 500ms
- timeout increased from 10s to 15s to check for windivert service
- bcdedit tests