### PR TITLE
docs: align CONTRIBUTING with canonical template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,32 @@
 # Contributing
 
+## Prerequisites
+
+To build this extension locally, you need:
+
+- [Go](https://go.dev/dl/) 1.26 or later (with Windows cross-compilation support if building from non-Windows)
+- [GNU Make](https://www.gnu.org/software/make/)
+- A Windows build environment for producing the MSI installer (the `installer` target requires a Windows host)
+
+## Getting Started
+
+1. Clone the repository
+2. `$ make tidy`
+3. `$ make build`
+
+## Tasks
+
+The `Makefile` in the project root contains commands to easily run common admin tasks. Run `make help` to list all available targets.
+
+| Command            | Meaning                                                                     |
+|--------------------|-----------------------------------------------------------------------------|
+| `$ make tidy`      | Format all code using `go fmt` and tidy the `go.mod` file.                  |
+| `$ make audit`     | Run `go vet`, `staticcheck`, execute all tests and verify required modules. |
+| `$ make build`     | Build the Windows extension binary.                                         |
+| `$ make release`   | Package the extension for release.                                          |
+| `$ make artifact`  | Package a ZIP with the extension and all required files.                    |
+| `$ make installer` | Build the Windows MSI installer (requires Windows host).                    |
+
 ## Releasing the Code
 
 To make a new release, do the following:


### PR DESCRIPTION
## Summary

Align CONTRIBUTING.md with the canonical Windows-extension variant of the Steadybit contributing template.

- Add an explicit **Prerequisites** section (Go, Make, a Windows build environment for the MSI installer).
- Add a **Getting Started** quick-start and a **Tasks** table covering the actual Makefile targets (`tidy`, `audit`, `build`, `release`, `artifact`, `installer`).
- Keep the existing release and CLA sections.

No `Dockerfile`/`charts/` in this repo, so the Docker and Helm sections from the standard template are intentionally omitted.