### PR TITLE
chore: normalize dependabot-auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@v3 # NOSONAR githubactions:S7637 - verified action creator
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs


### PR DESCRIPTION
Sync the `dependabot-auto-merge.yml` workflow to the standard version used across the other extensions and kits. No behavioral change — comment/whitespace only (this repo's copy had drifted). Branch protection and auto-merge are already configured here.