### PR TITLE
feat: add exclude IPs/CIDRs parameter to WinDivert network attacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: new `Exclude IPs/CIDRs` parameter (`excludeIp`) on the WinDivert-based network attacks (delay, blackhole, package loss, package corruption) — affect all traffic except the given IPs/CIDRs. Excludes always take precedence over the include restrictions. The existing filter parameters are relabeled to `Include Hostnames`, `Include IPs/CIDRs` and `Include Ports` to make the distinction explicit. The bandwidth attack is not covered: Windows QoS policies only support include-style match conditions.
+
 ## v0.2.14
 
 - build(deps): bump github.com/steadybit/action-kit/go/action_kit_commons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- feat: new `Exclude IPs/CIDRs` parameter (`excludeIp`) on the WinDivert-based network attacks (delay, blackhole, package loss, package corruption) — affect all traffic except the given IPs/CIDRs. Excludes always take precedence over the include restrictions. The existing filter parameters are relabeled to `Include Hostnames`, `Include IPs/CIDRs` and `Include Ports` to make the distinction explicit. The bandwidth attack is not covered: Windows QoS policies only support include-style match conditions.
+- feat: new `Exclude Hostnames` (`excludeHostname`) and `Exclude IPs/CIDRs` (`excludeIp`) parameters on the WinDivert-based network attacks (delay, blackhole, package loss, package corruption) — affect all traffic except the given hosts or IPs/CIDRs. Excludes always take precedence over the include restrictions. The existing filter parameters are relabeled to `Include Hostnames`, `Include IPs/CIDRs` and `Include Ports` to make the distinction explicit. The bandwidth attack is not covered: Windows QoS policies only support include-style match conditions.
 
 ## v0.2.14
 

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -154,6 +154,7 @@ func testNetworkDelay(t *testing.T, l Environment, e Extension) {
 		ip                  []string
 		hostname            []string
 		port                []string
+		excludeIp           []string
 		interfaces          []string
 		restrictedEndpoints []action_kit_api.RestrictedEndpoint
 		wantedDelay         bool
@@ -188,6 +189,12 @@ func testNetworkDelay(t *testing.T, l Environment, e Extension) {
 			wantedDelay:         true,
 		},
 		{
+			name:                "should not delay traffic for excluded cidr",
+			excludeIp:           []string{fmt.Sprintf("%s/32", netperf.Ip)},
+			restrictedEndpoints: generateRestrictedEndpoints(restrictedEndpointsCount),
+			wantedDelay:         false,
+		},
+		{
 			name:        "should delay all interfaces",
 			interfaces:  network.GetOwnNetworkInterfaces(),
 			wantedDelay: true,
@@ -207,6 +214,7 @@ func testNetworkDelay(t *testing.T, l Environment, e Extension) {
 			Ip           []string `json:"ip"`
 			Hostname     []string `json:"hostname"`
 			Port         []string `json:"port"`
+			ExcludeIp    []string `json:"excludeIp"`
 			NetInterface []string `json:"networkInterface"`
 		}{
 			Duration:     10000,
@@ -215,6 +223,7 @@ func testNetworkDelay(t *testing.T, l Environment, e Extension) {
 			Ip:           tt.ip,
 			Hostname:     tt.hostname,
 			Port:         tt.port,
+			ExcludeIp:    tt.excludeIp,
 			NetInterface: tt.interfaces,
 		}
 

--- a/exthostwindows/action_network.go
+++ b/exthostwindows/action_network.go
@@ -56,7 +56,7 @@ var networkInterfaceParameter = action_kit_api.ActionParameter{
 	Description: new("Target Network Interface which should be affected. All if none specified."),
 	Type:        action_kit_api.ActionParameterTypeStringArray,
 	Required:    new(false),
-	Order:       new(105),
+	Order:       new(106),
 }
 
 var commonNetworkParameters = []action_kit_api.ActionParameter{
@@ -89,13 +89,22 @@ var commonNetworkParameters = []action_kit_api.ActionParameter{
 		Order:        new(103),
 	},
 	{
+		Name:        "excludeHostname",
+		Label:       "Exclude Hostnames",
+		Description: new("Exclude traffic to/from these hosts from being affected. Excludes always take precedence over the include restrictions above (hostnames, IPs/CIDRs, ports)."),
+		Type:        action_kit_api.ActionParameterTypeStringArray,
+		Required:    new(false),
+		Advanced:    new(true),
+		Order:       new(104),
+	},
+	{
 		Name:        "excludeIp",
 		Label:       "Exclude IPs/CIDRs",
 		Description: new("Exclude traffic to/from these IP addresses or CIDR blocks from being affected. Excludes always take precedence over the include restrictions above (hostnames, IPs/CIDRs, ports), e.g. affect all traffic except 10.0.0.0/8."),
 		Type:        action_kit_api.ActionParameterTypeStringArray,
 		Required:    new(false),
 		Advanced:    new(true),
-		Order:       new(104),
+		Order:       new(105),
 	},
 }
 
@@ -207,7 +216,10 @@ func mapToNetworkFilter(ctx context.Context, actionConfig map[string]any, restri
 		return network.Filter{}, nil, err
 	}
 
-	excludeCidrs, err := utils.MapToNetworks(ctx, extutil.ToStringArray(actionConfig["excludeIp"])...)
+	excludeCidrs, err := utils.MapToNetworks(ctx, append(
+		extutil.ToStringArray(actionConfig["excludeIp"]),
+		extutil.ToStringArray(actionConfig["excludeHostname"])...,
+	)...)
 	if err != nil {
 		return network.Filter{}, nil, err
 	}

--- a/exthostwindows/action_network.go
+++ b/exthostwindows/action_network.go
@@ -56,14 +56,14 @@ var networkInterfaceParameter = action_kit_api.ActionParameter{
 	Description: new("Target Network Interface which should be affected. All if none specified."),
 	Type:        action_kit_api.ActionParameterTypeStringArray,
 	Required:    new(false),
-	Order:       new(104),
+	Order:       new(105),
 }
 
 var commonNetworkParameters = []action_kit_api.ActionParameter{
 	durationParamter,
 	{
 		Name:         "hostname",
-		Label:        "Hostnames",
+		Label:        "Include Hostnames",
 		Description:  new("Restrict to/from which hosts the traffic is affected."),
 		Type:         action_kit_api.ActionParameterTypeStringArray,
 		DefaultValue: new(""),
@@ -72,7 +72,7 @@ var commonNetworkParameters = []action_kit_api.ActionParameter{
 	},
 	{
 		Name:         "ip",
-		Label:        "IPs/CIDRs",
+		Label:        "Include IPs/CIDRs",
 		Description:  new("Restrict to/from which IP addresses or blocks the traffic is affected."),
 		Type:         action_kit_api.ActionParameterTypeStringArray,
 		DefaultValue: new(""),
@@ -81,12 +81,21 @@ var commonNetworkParameters = []action_kit_api.ActionParameter{
 	},
 	{
 		Name:         "port",
-		Label:        "Ports",
+		Label:        "Include Ports",
 		Description:  new("Restrict to/from which ports the traffic is affected."),
 		Type:         action_kit_api.ActionParameterTypeStringArray,
 		DefaultValue: new(""),
 		Advanced:     new(true),
 		Order:        new(103),
+	},
+	{
+		Name:        "excludeIp",
+		Label:       "Exclude IPs/CIDRs",
+		Description: new("Exclude traffic to/from these IP addresses or CIDR blocks from being affected. Excludes always take precedence over the include restrictions above (hostnames, IPs/CIDRs, ports), e.g. affect all traffic except 10.0.0.0/8."),
+		Type:        action_kit_api.ActionParameterTypeStringArray,
+		Required:    new(false),
+		Advanced:    new(true),
+		Order:       new(104),
 	},
 }
 
@@ -189,14 +198,24 @@ func mapToNetworkFilter(ctx context.Context, actionConfig map[string]any, restri
 	}
 
 	includes := akn.NewNetWithPortRanges(includeCidrs, portRanges...)
-	for _, i := range includes {
-		i.Comment = "parameters"
+	for i := range includes {
+		includes[i].Comment = "parameters"
 	}
 
 	excludes, err := toExcludes(restrictedEndpoints)
 	if err != nil {
 		return network.Filter{}, nil, err
 	}
+
+	excludeCidrs, err := utils.MapToNetworks(ctx, extutil.ToStringArray(actionConfig["excludeIp"])...)
+	if err != nil {
+		return network.Filter{}, nil, err
+	}
+	userExcludes := akn.NewNetWithPortRanges(excludeCidrs, akn.PortRangeAny)
+	for i := range userExcludes {
+		userExcludes[i].Comment = "parameters"
+	}
+	excludes = append(excludes, userExcludes...)
 
 	excludes = append(excludes, akn.ComputeExcludesForOwnIpAndPorts(config.Config.Port, config.Config.HealthPort)...)
 

--- a/exthostwindows/action_network_test.go
+++ b/exthostwindows/action_network_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package exthostwindows
+
+import (
+	"context"
+	"testing"
+
+	akn "github.com/steadybit/action-kit/go/action_kit_commons/network"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_mapToNetworkFilter_excludeIp(t *testing.T) {
+	tests := []struct {
+		name         string
+		actionConfig map[string]any
+		wantExcluded []string
+	}{
+		{
+			name:         "no excludeIp yields no parameter excludes",
+			actionConfig: map[string]any{},
+			wantExcluded: nil,
+		},
+		{
+			name: "excludeIp CIDRs and IPs are excluded on all ports",
+			actionConfig: map[string]any{
+				"excludeIp": []interface{}{"10.0.0.0/8", "192.168.1.1"},
+			},
+			wantExcluded: []string{"10.0.0.0/8 # parameters", "192.168.1.1/32 # parameters"},
+		},
+		{
+			name: "excludeIp composes with include restrictions",
+			actionConfig: map[string]any{
+				"ip":        []interface{}{"10.0.0.0/8"},
+				"excludeIp": []interface{}{"10.1.0.0/16"},
+			},
+			wantExcluded: []string{"10.1.0.0/16 # parameters"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter, _, err := mapToNetworkFilter(context.Background(), tt.actionConfig, nil)
+			require.NoError(t, err)
+
+			var parameterExcludes []string
+			for _, e := range filter.Exclude {
+				if e.Comment == "parameters" {
+					require.Equal(t, akn.PortRangeAny, e.PortRange)
+					parameterExcludes = append(parameterExcludes, e.String())
+				}
+			}
+			require.Equal(t, tt.wantExcluded, parameterExcludes)
+
+			for _, i := range filter.Include {
+				require.Equal(t, "parameters", i.Comment)
+			}
+		})
+	}
+}

--- a/exthostwindows/action_network_test.go
+++ b/exthostwindows/action_network_test.go
@@ -37,6 +37,14 @@ func Test_mapToNetworkFilter_excludeIp(t *testing.T) {
 			},
 			wantExcluded: []string{"10.1.0.0/16 # parameters"},
 		},
+		{
+			name: "excludeHostname entries are excluded together with excludeIp",
+			actionConfig: map[string]any{
+				"excludeIp":       []interface{}{"10.0.0.0/8"},
+				"excludeHostname": []interface{}{"192.168.1.1"},
+			},
+			wantExcluded: []string{"10.0.0.0/8 # parameters", "192.168.1.1/32 # parameters"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Adds a new advanced parameter **Exclude IPs/CIDRs** (`excludeIp`) to the network attacks using the shared hostname/IP/port filters — delay, blackhole, package loss, package corruption — making it possible to affect all traffic *except* some CIDRs (e.g. leave the include filters empty and exclude `10.0.0.0/8`). Hostnames are accepted too and resolved via the same logic as the include filters.

The existing filter parameters are relabeled to **Include Hostnames**, **Include IPs/CIDRs** and **Include Ports** to make explicit that they are includes as opposed to the new exclude parameter.

Windows counterpart of steadybit/extension-host#228 and steadybit/extension-container#471.

## Not covered: bandwidth

The bandwidth attack uses Windows QoS policies (`New-NetQosPolicy -IPDstPrefixMatchCondition`), which only support include-style match conditions — there is no way to express an exclusion there. All WinDivert-based attacks are covered.

## How

- `mapToNetworkFilter` (shared by the WinDivert attacks) parses `excludeIp` via `utils.MapToNetworks` (CIDR parse + DNS resolution) and appends the resulting nets on all ports to the filter's exclude list, next to the existing agent/extension protection excludes.
- The parameter lives in `commonNetworkParameters` (advanced, order 104, right after the include filters); `networkInterfaceParameter` was bumped to 105 to keep the filter block together in the UI.
- Excludes always take precedence over includes by construction: `buildWinDivertFilter` ANDs the exclude conditions after the include group, so a packet matching an exclude never matches the overall filter — regardless of CIDR specificity.

## Tests

- New unit tests for `mapToNetworkFilter` covering default (no excludes), exclude CIDRs/IPs on all ports, and exclude composing with an include restriction (run on the Windows CI runners).
- New e2e delay test case "should not delay traffic for excluded cidr".
- Verified locally with `GOOS=windows go build ./...` and `GOOS=windows go vet ./...`.

## Drive-by fix

The loop setting `Comment = "parameters"` on the include filters assigned to a range copy, so the comments never appeared in log output. Fixed to assign via index (same fix as in the Linux extensions).