### PR TITLE
fix: network attacks now affect portless protocols (e.g. ICMP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.3
+
+- fix: WinDivert-based network attacks (delay, blackhole, package loss, package corruption) now also affect protocols without ports (e.g. ICMP) when no port is specified. The filter previously matched only `tcp`/`udp` packets, so portless traffic such as `ping` slipped through the attack.
+
 ## v0.3.2
 
 - build(deps): bump actions/setup-go from 6 to 7

--- a/exthostwindows/network/windivert.go
+++ b/exthostwindows/network/windivert.go
@@ -8,10 +8,10 @@ import (
 	"net"
 	"os"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/rs/zerolog/log"
+	akn "github.com/steadybit/action-kit/go/action_kit_commons/network"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/mgr"
 )
@@ -75,14 +75,13 @@ func getStartEndIP(ipNet net.IPNet) (net.IP, net.IP, error) {
 	return nil, nil, fmt.Errorf("not implemented")
 }
 
-func setCorrectReplacements(replacements *map[string]string, family Family) {
-	if family == FamilyV4 {
-		(*replacements)["ipDstAddr"] = "ip.DstAddr"
-		(*replacements)["ipSrcAddr"] = "ip.SrcAddr"
-	} else {
-		(*replacements)["ipDstAddr"] = "ipv6.DstAddr"
-		(*replacements)["ipSrcAddr"] = "ipv6.SrcAddr"
+// addressFields returns the WinDivert destination and source address field
+// names for the given family (ip.* for IPv4, ipv6.* for IPv6).
+func addressFields(family Family) (dst, src string) {
+	if family == FamilyV6 {
+		return "ipv6.DstAddr", "ipv6.SrcAddr"
 	}
+	return "ip.DstAddr", "ip.SrcAddr"
 }
 
 const openGroup string = " and ("
@@ -91,7 +90,10 @@ const closeGroup string = ")"
 func buildWinDivertFilter(f Filter) (string, error) {
 	var sb strings.Builder
 
-	sb.WriteString("(tcp or udp)")
+	// Start from a protocol-agnostic base so portless protocols (e.g. ICMP) are
+	// matched as well. The include/exclude clauses restrict to tcp/udp only where
+	// a port is specified; when no port is given they match every protocol.
+	sb.WriteString("true")
 
 	if f.Direction != DirectionAll {
 		writeDirectionFilter(&sb, f.Direction)
@@ -138,56 +140,21 @@ func writeInterfaceFilter(sb *strings.Builder, ifIdxs []int) {
 }
 
 func writeIncludeFilter(sb *strings.Builder, filter Filter, direction Direction) error {
-	replaceMap := map[string]string{
-		"tcpDstPort": "tcp.DstPort",
-		"udpDstPort": "udp.DstPort",
-		"tcpSrcPort": "tcp.SrcPort",
-		"udpSrcPort": "udp.SrcPort",
-	}
-
 	sb.WriteString(openGroup)
 	for i, ran := range filter.Include {
 		family, err := getFamily(ran.Net)
 		if err != nil {
 			return err
 		}
+		dstAddr, srcAddr := addressFields(family)
 
-		setCorrectReplacements(&replaceMap, family)
+		startIp, endIp, err := getStartEndIP(ran.Net)
+		if err != nil {
+			return err
+		}
+
 		if direction != DirectionIncoming {
-			var portFilter string
-
-			if ran.PortRange.From == ran.PortRange.To {
-				portFilter = fmt.Sprintf("(( {{.tcpDstPort}} == %d ) or ( {{.udpDstPort}} == %d ))",
-					ran.PortRange.From, ran.PortRange.From)
-			} else {
-				portFilter = fmt.Sprintf("(( {{.tcpDstPort}} >= %d and {{.tcpDstPort}} <= %d ) or ( {{.udpDstPort}} >= %d and {{.udpDstPort}} <= %d ))",
-					ran.PortRange.From, ran.PortRange.To, ran.PortRange.From, ran.PortRange.To)
-			}
-
-			startIp, endIp, err := getStartEndIP(ran.Net)
-			if err != nil {
-				return err
-			}
-
-			var config string
-
-			if startIp.String() == endIp.String() {
-				config = fmt.Sprintf("( {{.ipDstAddr}} == %s and %s)",
-					startIp.String(), portFilter)
-			} else {
-				config = fmt.Sprintf("( {{.ipDstAddr}} >= %s and {{.ipDstAddr}} <= %s and %s)",
-					startIp.String(), endIp.String(), portFilter)
-			}
-
-			tmpl, err := template.New("filter").Parse(config)
-			if err != nil {
-				return err
-			}
-
-			err = tmpl.Execute(sb, replaceMap)
-			if err != nil {
-				return err
-			}
+			sb.WriteString(includeClause(dstAddr, "tcp.DstPort", "udp.DstPort", ran.PortRange, startIp, endIp))
 		}
 
 		if direction == DirectionAll {
@@ -195,40 +162,7 @@ func writeIncludeFilter(sb *strings.Builder, filter Filter, direction Direction)
 		}
 
 		if direction != DirectionOutgoing {
-			var portFilter string
-
-			if ran.PortRange.From == ran.PortRange.To {
-				portFilter = fmt.Sprintf("(( {{.tcpSrcPort}} == %d ) or ( {{.udpSrcPort}} == %d ))",
-					ran.PortRange.From, ran.PortRange.From)
-			} else {
-				portFilter = fmt.Sprintf("(( {{.tcpSrcPort}} >= %d and {{.tcpSrcPort}} <= %d ) or ( {{.udpSrcPort}} >= %d and {{.udpSrcPort}} <= %d ))",
-					ran.PortRange.From, ran.PortRange.To, ran.PortRange.From, ran.PortRange.To)
-			}
-
-			startIp, endIp, err := getStartEndIP(ran.Net)
-			if err != nil {
-				return err
-			}
-
-			var config string
-
-			if startIp.String() == endIp.String() {
-				config = fmt.Sprintf("( {{.ipSrcAddr}} == %s and %s)",
-					startIp.String(), portFilter)
-			} else {
-				config = fmt.Sprintf("( {{.ipSrcAddr}} >= %s and {{.ipSrcAddr}} <= %s and %s)",
-					startIp.String(), endIp.String(), portFilter)
-			}
-
-			tmpl, err := template.New("filter").Parse(config)
-			if err != nil {
-				return err
-			}
-
-			err = tmpl.Execute(sb, replaceMap)
-			if err != nil {
-				return err
-			}
+			sb.WriteString(includeClause(srcAddr, "tcp.SrcPort", "udp.SrcPort", ran.PortRange, startIp, endIp))
 		}
 
 		if i < len(filter.Include)-1 {
@@ -240,89 +174,22 @@ func writeIncludeFilter(sb *strings.Builder, filter Filter, direction Direction)
 }
 
 func writeExcludeFilter(sb *strings.Builder, filter Filter) error {
-	replaceMap := map[string]string{
-		"tcpDstPort": "tcp.DstPort",
-		"udpDstPort": "udp.DstPort",
-		"tcpSrcPort": "tcp.SrcPort",
-		"udpSrcPort": "udp.SrcPort",
-	}
-
 	sb.WriteString(openGroup)
 	for i, ran := range filter.Exclude {
 		family, err := getFamily(ran.Net)
 		if err != nil {
 			return err
 		}
-
-		setCorrectReplacements(&replaceMap, family)
-
-		var portFilter string
-
-		if ran.PortRange.From == ran.PortRange.To {
-			portFilter = fmt.Sprintf("(( {{.tcpDstPort}} != %d ) or ( {{.udpDstPort}} != %d ))",
-				ran.PortRange.From, ran.PortRange.To)
-		} else {
-			portFilter = fmt.Sprintf("(( {{.tcpDstPort}} < %d or {{.tcpDstPort}} > %d ) or ( {{.udpDstPort}} < %d or {{.udpDstPort}} > %d ))",
-				ran.PortRange.From, ran.PortRange.To, ran.PortRange.From, ran.PortRange.To)
-		}
+		dstAddr, srcAddr := addressFields(family)
 
 		startIp, endIp, err := getStartEndIP(ran.Net)
 		if err != nil {
 			return err
 		}
 
-		var config string
-
-		if startIp.String() == endIp.String() {
-			config = fmt.Sprintf("(( {{.ipDstAddr}} == %s )? %s: true)",
-				startIp.String(), portFilter)
-		} else {
-			config = fmt.Sprintf("(( {{.ipDstAddr}} >= %s and {{.ipDstAddr}} <= %s )? %s: true)",
-				startIp.String(), endIp.String(), portFilter)
-		}
-
-		tmpl, err := template.New("filter").Parse(config)
-		if err != nil {
-			return err
-		}
-
-		err = tmpl.Execute(sb, replaceMap)
-		if err != nil {
-			return err
-		}
-
+		sb.WriteString(excludeClause(dstAddr, "tcp.DstPort", "udp.DstPort", ran.PortRange, startIp, endIp))
 		sb.WriteString(" and ")
-
-		if ran.PortRange.From == ran.PortRange.To {
-			portFilter = fmt.Sprintf("(( {{.tcpSrcPort}} != %d ) or ( {{.udpSrcPort}} != %d ))",
-				ran.PortRange.From, ran.PortRange.To)
-		} else {
-			portFilter = fmt.Sprintf("(( {{.tcpSrcPort}} < %d or {{.tcpSrcPort}} > %d ) or ( {{.udpSrcPort}} < %d or {{.udpSrcPort}} > %d ))",
-				ran.PortRange.From, ran.PortRange.To, ran.PortRange.From, ran.PortRange.To)
-		}
-
-		startIp, endIp, err = getStartEndIP(ran.Net)
-		if err != nil {
-			return err
-		}
-
-		if startIp.String() == endIp.String() {
-			config = fmt.Sprintf("(( {{.ipSrcAddr}} == %s )? %s: true)",
-				startIp.String(), portFilter)
-		} else {
-			config = fmt.Sprintf("(( {{.ipSrcAddr}} >= %s and {{.ipSrcAddr}} <= %s )? %s: true)",
-				startIp.String(), endIp.String(), portFilter)
-		}
-
-		tmpl, err = template.New("filter").Parse(config)
-		if err != nil {
-			return err
-		}
-
-		err = tmpl.Execute(sb, replaceMap)
-		if err != nil {
-			return err
-		}
+		sb.WriteString(excludeClause(srcAddr, "tcp.SrcPort", "udp.SrcPort", ran.PortRange, startIp, endIp))
 
 		if i < len(filter.Exclude)-1 {
 			sb.WriteString(" and ")
@@ -331,6 +198,51 @@ func writeExcludeFilter(sb *strings.Builder, filter Filter) error {
 
 	sb.WriteString(closeGroup)
 	return nil
+}
+
+// addressMatch renders the `<addrField> ...` fragment matching a single address
+// or an inclusive address range.
+func addressMatch(addrField string, startIp, endIp net.IP) string {
+	if startIp.String() == endIp.String() {
+		return fmt.Sprintf("%s == %s", addrField, startIp.String())
+	}
+	return fmt.Sprintf("%s >= %s and %s <= %s", addrField, startIp.String(), addrField, endIp.String())
+}
+
+// includeClause builds a WinDivert sub-expression matching traffic to/from the
+// given address range. For the any-port wildcard it matches every protocol
+// (including portless ones such as ICMP); otherwise it restricts to the tcp/udp
+// packets whose port falls in the range.
+func includeClause(addrField, tcpPortField, udpPortField string, portRange akn.PortRange, startIp, endIp net.IP) string {
+	addr := addressMatch(addrField, startIp, endIp)
+	if portRange == akn.PortRangeAny {
+		return fmt.Sprintf("( %s )", addr)
+	}
+
+	var portFilter string
+	if portRange.From == portRange.To {
+		portFilter = fmt.Sprintf("(( %s == %d ) or ( %s == %d ))", tcpPortField, portRange.From, udpPortField, portRange.From)
+	} else {
+		portFilter = fmt.Sprintf("(( %s >= %d and %s <= %d ) or ( %s >= %d and %s <= %d ))", tcpPortField, portRange.From, tcpPortField, portRange.To, udpPortField, portRange.From, udpPortField, portRange.To)
+	}
+	return fmt.Sprintf("( %s and %s)", addr, portFilter)
+}
+
+// excludeClause builds a WinDivert sub-expression that spares traffic to/from
+// the given address range. For the any-port wildcard it excludes every protocol
+// on that address; otherwise it only excludes the tcp/udp packets whose port
+// falls in the range.
+func excludeClause(addrField, tcpPortField, udpPortField string, portRange akn.PortRange, startIp, endIp net.IP) string {
+	addr := addressMatch(addrField, startIp, endIp)
+	spare := "false"
+	if portRange != akn.PortRangeAny {
+		if portRange.From == portRange.To {
+			spare = fmt.Sprintf("(( %s != %d ) or ( %s != %d ))", tcpPortField, portRange.From, udpPortField, portRange.From)
+		} else {
+			spare = fmt.Sprintf("(( %s < %d or %s > %d ) or ( %s < %d or %s > %d ))", tcpPortField, portRange.From, tcpPortField, portRange.To, udpPortField, portRange.From, udpPortField, portRange.To)
+		}
+	}
+	return fmt.Sprintf("(( %s )? %s: true)", addr, spare)
 }
 
 func buildWinDivertFilterFile(f Filter) (string, error) {

--- a/exthostwindows/network/windivert_test.go
+++ b/exthostwindows/network/windivert_test.go
@@ -51,7 +51,7 @@ func TestWinDivertBuildFilterInclude(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "(tcp or udp) and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 ))))", filter)
+	assert.Equal(t, "true and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 ))))", filter)
 }
 
 func TestWinDivertBuildFilterIncludeInbound(t *testing.T) {
@@ -71,7 +71,7 @@ func TestWinDivertBuildFilterIncludeInbound(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "(tcp or udp) and inbound and (( ip.SrcAddr >= 1.1.1.0 and ip.SrcAddr <= 1.1.1.255 and (( tcp.SrcPort >= 8000 and tcp.SrcPort <= 8002 ) or ( udp.SrcPort >= 8000 and udp.SrcPort <= 8002 ))))", filter)
+	assert.Equal(t, "true and inbound and (( ip.SrcAddr >= 1.1.1.0 and ip.SrcAddr <= 1.1.1.255 and (( tcp.SrcPort >= 8000 and tcp.SrcPort <= 8002 ) or ( udp.SrcPort >= 8000 and udp.SrcPort <= 8002 ))))", filter)
 }
 
 func TestWinDivertBuildFilterIncludeInOut(t *testing.T) {
@@ -91,7 +91,7 @@ func TestWinDivertBuildFilterIncludeInOut(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "(tcp or udp) and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 ))) or ( ip.SrcAddr >= 1.1.1.0 and ip.SrcAddr <= 1.1.1.255 and (( tcp.SrcPort >= 8000 and tcp.SrcPort <= 8002 ) or ( udp.SrcPort >= 8000 and udp.SrcPort <= 8002 ))))", filter)
+	assert.Equal(t, "true and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 ))) or ( ip.SrcAddr >= 1.1.1.0 and ip.SrcAddr <= 1.1.1.255 and (( tcp.SrcPort >= 8000 and tcp.SrcPort <= 8002 ) or ( udp.SrcPort >= 8000 and udp.SrcPort <= 8002 ))))", filter)
 }
 
 func TestWinDivertBuildFilterIncludeIpv6(t *testing.T) {
@@ -111,7 +111,7 @@ func TestWinDivertBuildFilterIncludeIpv6(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "(tcp or udp) and outbound and (( ipv6.DstAddr >= :: and ipv6.DstAddr <= ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 ))))", filter)
+	assert.Equal(t, "true and outbound and (( ipv6.DstAddr >= :: and ipv6.DstAddr <= ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 ))))", filter)
 }
 
 func TestWinDivertBuildFilterExclude(t *testing.T) {
@@ -140,7 +140,7 @@ func TestWinDivertBuildFilterExclude(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "(tcp or udp) and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 )))) and ((( ip.DstAddr == 1.1.1.0 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.0 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
+	assert.Equal(t, "true and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 )))) and ((( ip.DstAddr == 1.1.1.0 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.0 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
 }
 
 func TestWinDivertBuildFilterMultipleExcludes(t *testing.T) {
@@ -176,7 +176,7 @@ func TestWinDivertBuildFilterMultipleExcludes(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "(tcp or udp) and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 )))) and ((( ip.DstAddr == 1.1.1.0 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.0 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true) and (( ip.DstAddr == 1.1.1.1 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.1 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
+	assert.Equal(t, "true and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 )))) and ((( ip.DstAddr == 1.1.1.0 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.0 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true) and (( ip.DstAddr == 1.1.1.1 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.1 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
 }
 
 func TestWinDivertBuildFilterMultipleIncludes(t *testing.T) {
@@ -212,7 +212,7 @@ func TestWinDivertBuildFilterMultipleIncludes(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "(tcp or udp) and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 ))) or ( ip.DstAddr >= 1.1.2.0 and ip.DstAddr <= 1.1.2.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 )))) and ((( ip.DstAddr == 1.1.1.0 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.0 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
+	assert.Equal(t, "true and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 ))) or ( ip.DstAddr >= 1.1.2.0 and ip.DstAddr <= 1.1.2.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 )))) and ((( ip.DstAddr == 1.1.1.0 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.0 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
 }
 
 func TestWinDivertBuildFilterOnlyExclude(t *testing.T) {
@@ -232,7 +232,7 @@ func TestWinDivertBuildFilterOnlyExclude(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "(tcp or udp) and outbound and ((( ip.DstAddr == 1.1.1.14 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.14 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
+	assert.Equal(t, "true and outbound and ((( ip.DstAddr == 1.1.1.14 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.14 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
 }
 
 func TestWinDivertBuildFilterInterfaces(t *testing.T) {
@@ -241,7 +241,7 @@ func TestWinDivertBuildFilterInterfaces(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	assert.Equal(t, "(tcp or udp) and outbound and (ifIdx == 1 or ifIdx == 2 or ifIdx == 3)", filter)
+	assert.Equal(t, "true and outbound and (ifIdx == 1 or ifIdx == 2 or ifIdx == 3)", filter)
 }
 
 func TestWinDivertBuildFilterInterfacesAndIncludeOutgoing(t *testing.T) {
@@ -262,7 +262,7 @@ func TestWinDivertBuildFilterInterfacesAndIncludeOutgoing(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "(tcp or udp) and outbound and (ifIdx == 1 or ifIdx == 2 or ifIdx == 3) and ((( ip.DstAddr == 1.1.1.14 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.14 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
+	assert.Equal(t, "true and outbound and (ifIdx == 1 or ifIdx == 2 or ifIdx == 3) and ((( ip.DstAddr == 1.1.1.14 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.14 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
 }
 
 func TestWinDivertBuildFilterInterfacesAndIncludeInbound(t *testing.T) {
@@ -283,33 +283,92 @@ func TestWinDivertBuildFilterInterfacesAndIncludeInbound(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "(tcp or udp) and inbound and (ifIdx == 1 or ifIdx == 2 or ifIdx == 3) and ((( ip.DstAddr == 1.1.1.14 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.14 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
+	assert.Equal(t, "true and inbound and (ifIdx == 1 or ifIdx == 2 or ifIdx == 3) and ((( ip.DstAddr == 1.1.1.14 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.14 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
 }
 
 func TestWinDivertBuildFilterDirection(t *testing.T) {
 	t.Run("unset", func(t *testing.T) {
 		filter, _ := buildWinDivertFilter(Filter{})
-		assert.Equal(t, "(tcp or udp) and outbound", filter)
+		assert.Equal(t, "true and outbound", filter)
 	})
 
 	t.Run("outgoing", func(t *testing.T) {
 		filter, _ := buildWinDivertFilter(Filter{
 			Direction: DirectionOutgoing,
 		})
-		assert.Equal(t, "(tcp or udp) and outbound", filter)
+		assert.Equal(t, "true and outbound", filter)
 	})
 
 	t.Run("incoming", func(t *testing.T) {
 		filter, _ := buildWinDivertFilter(Filter{
 			Direction: DirectionIncoming,
 		})
-		assert.Equal(t, "(tcp or udp) and inbound", filter)
+		assert.Equal(t, "true and inbound", filter)
 	})
 
 	t.Run("all", func(t *testing.T) {
 		filter, _ := buildWinDivertFilter(Filter{
 			Direction: DirectionAll,
 		})
-		assert.Equal(t, "(tcp or udp)", filter)
+		assert.Equal(t, "true", filter)
 	})
+}
+
+func TestWinDivertBuildFilterIncludeAnyPortMatchesAllProtocols(t *testing.T) {
+	net1, err := akn.ParseCIDR("1.1.1.1/24")
+	require.NoError(t, err)
+	f := Filter{
+		Direction: DirectionOutgoing,
+		Include: []akn.NetWithPortRange{
+			{
+				Net:       *net1,
+				PortRange: akn.PortRangeAny,
+			},
+		},
+	}
+
+	filter, err := buildWinDivertFilter(f)
+	assert.NoError(t, err)
+
+	// No port specified => no tcp/udp port filter => portless protocols (e.g. ICMP) match too.
+	assert.Equal(t, "true and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 ))", filter)
+}
+
+func TestWinDivertBuildFilterIncludeAnyPortInOut(t *testing.T) {
+	net1, err := akn.ParseCIDR("1.1.1.1/24")
+	require.NoError(t, err)
+	f := Filter{
+		Direction: DirectionAll,
+		Include: []akn.NetWithPortRange{
+			{
+				Net:       *net1,
+				PortRange: akn.PortRangeAny,
+			},
+		},
+	}
+
+	filter, err := buildWinDivertFilter(f)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "true and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 ) or ( ip.SrcAddr >= 1.1.1.0 and ip.SrcAddr <= 1.1.1.255 ))", filter)
+}
+
+func TestWinDivertBuildFilterExcludeAnyPortSparesAllProtocols(t *testing.T) {
+	excludeNet, err := akn.ParseCIDR("1.1.1.14")
+	require.NoError(t, err)
+	f := Filter{
+		Direction: DirectionOutgoing,
+		Exclude: []akn.NetWithPortRange{
+			{
+				Net:       *excludeNet,
+				PortRange: akn.PortRangeAny,
+			},
+		},
+	}
+
+	filter, err := buildWinDivertFilter(f)
+	assert.NoError(t, err)
+
+	// No port specified => the excluded address is spared for every protocol.
+	assert.Equal(t, "true and outbound and ((( ip.DstAddr == 1.1.1.14 )? false: true) and (( ip.SrcAddr == 1.1.1.14 )? false: true))", filter)
 }


### PR DESCRIPTION
## What

Completes BM 13054 for Windows: network attacks did not affect protocols without ports (e.g. ICMP), so `ping` slipped through the delay/blackhole/package-loss/package-corruption attacks. (Evidence in the ticket: a customer expected the Windows Host Delay attack to affect `ping`.)

The WinDivert filter always began with `(tcp or udp)`, and every include/exclude clause referenced tcp/udp port fields — so an unset port (any-port wildcard) still restricted matching to tcp/udp and never matched portless protocols.

## Change

- `fix`: start the WinDivert filter from a protocol-agnostic base (`true`) and omit the tcp/udp port sub-filter when no port is specified, so the WinDivert-based attacks (delay, blackhole, package loss, package corruption) affect every protocol to/from the targeted addresses. Port-scoped filters still match tcp/udp only, since those port fields exist solely on tcp/udp packets. The QoS-based bandwidth attack is unaffected (Windows QoS cannot target ICMP).
- Refactor: the per-clause `text/template` substitution is replaced by resolving the address field name directly; filter output is byte-identical.
- `test`: updated expectations for the new base and added portless (ICMP) include/exclude cases.

Mirrors the Linux fix in `action_kit_commons` v1.10.4 (steadybit/action-kit#472) and the extension-host / extension-container changes.

Ref: BusinessMap 13054
