### PR TITLE
fix: Windows network attacks now actually affect ICMP (port-scoped excludes + startup log)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.3.3
 
 - fix: WinDivert-based network attacks (delay, blackhole, package loss, package corruption) now also affect protocols without ports (e.g. ICMP) when no port is specified. The filter previously matched only `tcp`/`udp` packets, so portless traffic such as `ping` slipped through the attack. Port-scoped excludes now also only spare their tcp/udp port and no longer spare all ICMP traffic to/from the excluded address.
+- fix: the build information log line (and other early startup logs) is no longer dropped from the on-disk log / Windows Event Log — the log writer is now attached synchronously before startup logging instead of in a background goroutine.
 
 ## v0.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.3.3
 
-- fix: WinDivert-based network attacks (delay, blackhole, package loss, package corruption) now also affect protocols without ports (e.g. ICMP) when no port is specified. The filter previously matched only `tcp`/`udp` packets, so portless traffic such as `ping` slipped through the attack.
+- fix: WinDivert-based network attacks (delay, blackhole, package loss, package corruption) now also affect protocols without ports (e.g. ICMP) when no port is specified. The filter previously matched only `tcp`/`udp` packets, so portless traffic such as `ping` slipped through the attack. Port-scoped excludes now also only spare their tcp/udp port and no longer spare all ICMP traffic to/from the excluded address.
 
 ## v0.3.2
 

--- a/exthostwindows/network/windivert.go
+++ b/exthostwindows/network/windivert.go
@@ -236,10 +236,15 @@ func excludeClause(addrField, tcpPortField, udpPortField string, portRange akn.P
 	addr := addressMatch(addrField, startIp, endIp)
 	spare := "false"
 	if portRange != akn.PortRangeAny {
+		// A port-scoped exclude must spare only the tcp/udp packets whose port is
+		// in the range. Each port test is guarded with `not tcp`/`not udp` so that
+		// portless protocols (e.g. ICMP) stay subject to the attack — a bare port
+		// comparison is false for a packet that has no port, which would otherwise
+		// spare all ICMP to/from the excluded address.
 		if portRange.From == portRange.To {
-			spare = fmt.Sprintf("(( %s != %d ) or ( %s != %d ))", tcpPortField, portRange.From, udpPortField, portRange.From)
+			spare = fmt.Sprintf("(( not tcp or %s != %d ) and ( not udp or %s != %d ))", tcpPortField, portRange.From, udpPortField, portRange.From)
 		} else {
-			spare = fmt.Sprintf("(( %s < %d or %s > %d ) or ( %s < %d or %s > %d ))", tcpPortField, portRange.From, tcpPortField, portRange.To, udpPortField, portRange.From, udpPortField, portRange.To)
+			spare = fmt.Sprintf("(( not tcp or %s < %d or %s > %d ) and ( not udp or %s < %d or %s > %d ))", tcpPortField, portRange.From, tcpPortField, portRange.To, udpPortField, portRange.From, udpPortField, portRange.To)
 		}
 	}
 	return fmt.Sprintf("(( %s )? %s: true)", addr, spare)

--- a/exthostwindows/network/windivert_test.go
+++ b/exthostwindows/network/windivert_test.go
@@ -140,7 +140,7 @@ func TestWinDivertBuildFilterExclude(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "true and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 )))) and ((( ip.DstAddr == 1.1.1.0 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.0 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
+	assert.Equal(t, "true and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 )))) and ((( ip.DstAddr == 1.1.1.0 )? (( not tcp or tcp.DstPort < 8000 or tcp.DstPort > 8002 ) and ( not udp or udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.0 )? (( not tcp or tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) and ( not udp or udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
 }
 
 func TestWinDivertBuildFilterMultipleExcludes(t *testing.T) {
@@ -176,7 +176,7 @@ func TestWinDivertBuildFilterMultipleExcludes(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "true and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 )))) and ((( ip.DstAddr == 1.1.1.0 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.0 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true) and (( ip.DstAddr == 1.1.1.1 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.1 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
+	assert.Equal(t, "true and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 )))) and ((( ip.DstAddr == 1.1.1.0 )? (( not tcp or tcp.DstPort < 8000 or tcp.DstPort > 8002 ) and ( not udp or udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.0 )? (( not tcp or tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) and ( not udp or udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true) and (( ip.DstAddr == 1.1.1.1 )? (( not tcp or tcp.DstPort < 8000 or tcp.DstPort > 8002 ) and ( not udp or udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.1 )? (( not tcp or tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) and ( not udp or udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
 }
 
 func TestWinDivertBuildFilterMultipleIncludes(t *testing.T) {
@@ -212,7 +212,7 @@ func TestWinDivertBuildFilterMultipleIncludes(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "true and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 ))) or ( ip.DstAddr >= 1.1.2.0 and ip.DstAddr <= 1.1.2.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 )))) and ((( ip.DstAddr == 1.1.1.0 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.0 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
+	assert.Equal(t, "true and outbound and (( ip.DstAddr >= 1.1.1.0 and ip.DstAddr <= 1.1.1.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 ))) or ( ip.DstAddr >= 1.1.2.0 and ip.DstAddr <= 1.1.2.255 and (( tcp.DstPort >= 8000 and tcp.DstPort <= 8002 ) or ( udp.DstPort >= 8000 and udp.DstPort <= 8002 )))) and ((( ip.DstAddr == 1.1.1.0 )? (( not tcp or tcp.DstPort < 8000 or tcp.DstPort > 8002 ) and ( not udp or udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.0 )? (( not tcp or tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) and ( not udp or udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
 }
 
 func TestWinDivertBuildFilterOnlyExclude(t *testing.T) {
@@ -232,7 +232,7 @@ func TestWinDivertBuildFilterOnlyExclude(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "true and outbound and ((( ip.DstAddr == 1.1.1.14 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.14 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
+	assert.Equal(t, "true and outbound and ((( ip.DstAddr == 1.1.1.14 )? (( not tcp or tcp.DstPort < 8000 or tcp.DstPort > 8002 ) and ( not udp or udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.14 )? (( not tcp or tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) and ( not udp or udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
 }
 
 func TestWinDivertBuildFilterInterfaces(t *testing.T) {
@@ -262,7 +262,7 @@ func TestWinDivertBuildFilterInterfacesAndIncludeOutgoing(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "true and outbound and (ifIdx == 1 or ifIdx == 2 or ifIdx == 3) and ((( ip.DstAddr == 1.1.1.14 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.14 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
+	assert.Equal(t, "true and outbound and (ifIdx == 1 or ifIdx == 2 or ifIdx == 3) and ((( ip.DstAddr == 1.1.1.14 )? (( not tcp or tcp.DstPort < 8000 or tcp.DstPort > 8002 ) and ( not udp or udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.14 )? (( not tcp or tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) and ( not udp or udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
 }
 
 func TestWinDivertBuildFilterInterfacesAndIncludeInbound(t *testing.T) {
@@ -283,7 +283,7 @@ func TestWinDivertBuildFilterInterfacesAndIncludeInbound(t *testing.T) {
 	filter, err := buildWinDivertFilter(f)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "true and inbound and (ifIdx == 1 or ifIdx == 2 or ifIdx == 3) and ((( ip.DstAddr == 1.1.1.14 )? (( tcp.DstPort < 8000 or tcp.DstPort > 8002 ) or ( udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.14 )? (( tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) or ( udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
+	assert.Equal(t, "true and inbound and (ifIdx == 1 or ifIdx == 2 or ifIdx == 3) and ((( ip.DstAddr == 1.1.1.14 )? (( not tcp or tcp.DstPort < 8000 or tcp.DstPort > 8002 ) and ( not udp or udp.DstPort < 8000 or udp.DstPort > 8002 )): true) and (( ip.SrcAddr == 1.1.1.14 )? (( not tcp or tcp.SrcPort < 8000 or tcp.SrcPort > 8002 ) and ( not udp or udp.SrcPort < 8000 or udp.SrcPort > 8002 )): true))", filter)
 }
 
 func TestWinDivertBuildFilterDirection(t *testing.T) {
@@ -371,4 +371,29 @@ func TestWinDivertBuildFilterExcludeAnyPortSparesAllProtocols(t *testing.T) {
 
 	// No port specified => the excluded address is spared for every protocol.
 	assert.Equal(t, "true and outbound and ((( ip.DstAddr == 1.1.1.14 )? false: true) and (( ip.SrcAddr == 1.1.1.14 )? false: true))", filter)
+}
+
+func TestWinDivertBuildFilterPortScopedExcludeDoesNotSpareIcmp(t *testing.T) {
+	// Reproduces the real-world setup: a portless include on the attack target,
+	// plus an auto-added port-scoped exclude for the host's own address. The
+	// exclude must spare only its tcp/udp port and leave portless (ICMP) traffic
+	// subject to the attack, so `ping` from the host is not silently spared.
+	target, err := akn.ParseCIDR("10.0.0.5/32")
+	require.NoError(t, err)
+	host, err := akn.ParseCIDR("10.0.0.9/32")
+	require.NoError(t, err)
+	f := Filter{
+		Direction: DirectionAll,
+		Include: []akn.NetWithPortRange{
+			{Net: *target, PortRange: akn.PortRangeAny},
+		},
+		Exclude: []akn.NetWithPortRange{
+			{Net: *host, PortRange: akn.PortRange{From: 8085, To: 8085}},
+		},
+	}
+
+	filter, err := buildWinDivertFilter(f)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "true and (( ip.DstAddr == 10.0.0.5 ) or ( ip.SrcAddr == 10.0.0.5 )) and ((( ip.DstAddr == 10.0.0.9 )? (( not tcp or tcp.DstPort != 8085 ) and ( not udp or udp.DstPort != 8085 )): true) and (( ip.SrcAddr == 10.0.0.9 )? (( not tcp or tcp.SrcPort != 8085 ) and ( not udp or udp.SrcPort != 8085 )): true))", filter)
 }

--- a/exthostwindows/service.go
+++ b/exthostwindows/service.go
@@ -27,21 +27,27 @@ func ActivateWindowsServiceHandler(stopHandler func()) {
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to detect if executed as Windows service")
 	}
-	if isInService {
-		go func() {
-			service, err := newExtensionService(stopHandler)
-			if err != nil {
-				log.Fatal().Err(err).Msg("Error starting as Windows service")
-				return
-			}
-			err = service.Run()
-			if err != nil {
-				log.Fatal().Err(err).Msg("Error starting as Windows service")
-				return
-			}
-			log.Info().Msg("Windows service stopped")
-		}()
+	if !isInService {
+		return
 	}
+
+	// Attach the file/event-log writer synchronously, before returning to the
+	// startup sequence that emits the first log lines (e.g. build information).
+	// Only the blocking svc.Run loop runs in the goroutine; doing the writer
+	// setup there raced with startup logging and dropped the earliest lines.
+	service, err := newExtensionService(stopHandler)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Error starting as Windows service")
+		return
+	}
+
+	go func() {
+		if err := service.Run(); err != nil {
+			log.Fatal().Err(err).Msg("Error starting as Windows service")
+			return
+		}
+		log.Info().Msg("Windows service stopped")
+	}()
 }
 
 type extensionService struct {


### PR DESCRIPTION
## What

Follow-up to #194. Real-world testing on the Windows demo host showed that `ping` was **not** affected by the blackhole attack, even though #194 made the WinDivert filter match ICMP. Two issues, both fixed here.

### 1. Port-scoped excludes silently spared all ICMP (the ping bug)

The agent auto-adds the host's own address to the attack **excludes** on its control ports (agent `42899`, extension `8085`, health `8081`). The exclude "spare" condition was a bare port comparison:

```
(( tcp.SrcPort != 42899 ) or ( udp.SrcPort != 42899 ))
```

For an ICMP packet there are no tcp/udp ports, so both terms are **false** → the exclude fires → the packet is spared. Since `ping` originates from the host, **every ICMP packet from the host was spared** and the blackhole/delay/loss/corruption attacks had no effect on it. This was masked before #194 by the old `(tcp or udp)` filter base.

Fix: guard each port test with its protocol so a port-scoped exclude only spares its tcp/udp port and leaves portless traffic subject to the attack:

```
(( not tcp or tcp.SrcPort != 42899 ) and ( not udp or udp.SrcPort != 42899 ))
```

(`not`/`tcp`/`udp` are valid `steadybit/WinDivert` filter tokens, and `wdna.exe --mode=drop` drops matched packets protocol-agnostically at the network layer.)

### 2. Build-information log line dropped from the on-disk log

`ActivateWindowsServiceHandler` installed the file / Event-Log writer inside the goroutine running `svc.Run`, racing the startup log calls. The first line (`Build information: …`) lost the race to stdout (not captured by the service) and never hit disk. The writer is now attached synchronously before startup logging; only the blocking `svc.Run` loop stays in the goroutine.

## Tests

- Updated the exclude filter-string expectations for the protocol-guarded spare.
- Added a test reproducing the real setup: a portless include on the target plus a port-scoped exclude for the host, asserting ICMP is not spared.

Verified locally with `GOOS=windows` build + vet (the package is Windows-only; unit tests run on CI).

Ref: BusinessMap 13054
